### PR TITLE
`path` throws error, var unused.

### DIFF
--- a/bin/gulpboilerplate
+++ b/bin/gulpboilerplate
@@ -5,8 +5,7 @@ var
   path      = require('path'),
   pkg       = require('../package.json'),
   version   = pkg.version,
-  npm       = require('npm'),
-  dir       = path.dirname();
+  npm       = require('npm');
 
 // install gulp modules
 npm.load(function (err) {


### PR DESCRIPTION
`var dir` is never used and causes an error:

```
path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1324:5)
    at Object.<anonymous> (/Users/blackwood/.nvm/versions/node/v6.2.0/lib/node_modules/gulp-boilerplate/bin/gulpboilerplate:9:20)
```